### PR TITLE
Add "t" query to Twitter URL cleaning

### DIFF
--- a/data.min.json
+++ b/data.min.json
@@ -419,6 +419,7 @@
             "rules": [
                 "(?:ref_?)?src",
                 "s",
+                "t",
                 "cn",
                 "ref_url"
             ],


### PR DESCRIPTION
This seems like a relatively new addition by Twitter - almost certainly a tracking string or something. It's pissing me off because it's making the Twitter URLs obscenely long for no reason so I'm adding a rule here for it lol.

An example:

https://twitter.com/ELDENRING/status/1456267348822745097?t=8bNjsX6-jiKx19y360Yu4A&s=19