### PR TITLE
Fix video playback on Google Drive, in-browser

### DIFF
--- a/data.min.json
+++ b/data.min.json
@@ -150,7 +150,7 @@
             "exceptions": [
                 "^https?:\\/\\/mail\\.google\\.com\\/mail\\/u\\/",
                 "^https?:\\/\\/(?:docs|accounts)\\.google(?:\\.[a-z]{2,}){1,}",
-                "^https?:\\/\\/drive\\.google\\.com\\/videoplayback",
+                "^https?:\\/\\/([a-z0-9-\\.])*drive\\.google\\.com\\/videoplayback",
                 "^https?:\\/\\/(?:[a-z0-9-]+\\.)*?google(?:\\.[a-z]{2,}){1,}(?:\\/upload)?\\/drive\\/",
                 "^https?:\\/\\/news\\.google\\.com.*\\?hl=.",
                 "^https?:\\/\\/hangouts\\.google\\.com\\/webchat.*?zx=.",


### PR DESCRIPTION
Google uses several subdomains for fetching the actual `mp4` video content for its playback of video files on Google Drive, so the exception already added here isn't "enough" for whitelisting components on Drive.

Specifically the `ei=` tag and `source` parameters (I compared the urls used when having the extension enabled and disabled; those were the only noticeable differences) are seemingly required for proper video playback. Otherwise you'll get a plain `403` error.

Example:
```
https://abc---ab-abcdefg.a.drive.google.com/videoplayback?[...]
```

Tested and validated manually as well as with https://test.clearurls.xyz/

If you wish to try out the different ruleset you can use the following URLs, hosted on GitHub as well:

https://heiber.im/clearurls/data.minify.json
https://heiber.im/clearurls/rules.minify.hash

I'll keep these two files reachable up until such time this PR is merged and deployed. I will not update the ruleset periodically, whenever new changes are merged, though, so continue to use them at your own risk.

Likely fixes ClearURLs/Addon#120