### PR TITLE
Fix: Update rules for twitter

### DIFF
--- a/data.min.json
+++ b/data.min.json
@@ -429,6 +429,7 @@
                 "(?:ref_?)?src",
                 "s",
                 "cn",
+                "t",
                 "ref_url"
             ],
             "referralMarketing": [],


### PR DESCRIPTION
All links shared from twitter will now have a unique tracking parameter.
![chrome_CdeCLgJOjz](https://user-images.githubusercontent.com/45971730/165193616-26e7fe05-9458-45df-be87-869d18e05c1b.png)
`https://twitter.com/<username>/status/<twitter_id>?s=<platform_tracking>&t=<a_unique_string_with_letter_number_hyphen>`