### PR TITLE
Fixed chat video playback, uses separate sub-domain now

### DIFF
--- a/data.min.json
+++ b/data.min.json
@@ -150,7 +150,7 @@
             "exceptions": [
                 "^https?:\\/\\/mail\\.google\\.com\\/mail\\/u\\/",
                 "^https?:\\/\\/(?:docs|accounts)\\.google(?:\\.[a-z]{2,}){1,}",
-                "^https?:\\/\\/([a-z0-9-\\.])*drive\\.google\\.com\\/videoplayback",
+                "^https?:\\/\\/([a-z0-9-\\.])*(chat|drive)\\.google\\.com\\/videoplayback",
                 "^https?:\\/\\/(?:[a-z0-9-]+\\.)*?google(?:\\.[a-z]{2,}){1,}(?:\\/upload)?\\/drive\\/",
                 "^https?:\\/\\/news\\.google\\.com.*\\?hl=.",
                 "^https?:\\/\\/hangouts\\.google\\.com\\/webchat.*?zx=.",


### PR DESCRIPTION
Google Chat seems to have moved to its own domain for video playback as of late. This exception adds the Chat-specific sub-domain to the regexp that already exists in for Google Drive.