### PR TITLE
Fix https://github.com/ClearURLs/Rules/issues/77

### DIFF
--- a/data.min.json
+++ b/data.min.json
@@ -306,7 +306,8 @@
                 "^https?:\\/\\/button.like.co\\/in\\/.*?&?referrer=[^/?&]*",
                 "^https?:\\/\\/www\\.mma\\.go\\.kr",
                 "^https?:\\/\\/(?:[a-z0-9-]+\\.)*?github\\.com",
-                "^https?:\\/\\/(?:[a-z0-9-]+\\.)*?billiger\\.de\\/.*?mc="
+                "^https?:\\/\\/(?:[a-z0-9-]+\\.)*?billiger\\.de\\/.*?mc=",
+                "^https?:\\/\\cu\\.bankid\\.com"
             ],
             "redirections": [],
             "forceRedirection": false


### PR DESCRIPTION
Removing `ref` from `cu.bankid.com` causes breakage (https://github.com/ClearURLs/Rules/issues/77).
This PR excludes that domain from filtering