### PR TITLE
WIP: Fix microsoft Research redirects

### DIFF
--- a/data.min.json
+++ b/data.min.json
@@ -304,6 +304,7 @@
                 "^https?:\\/\\/(?:[a-z0-9-]+\\.)*?onet\\.pl\\/[^?]*\\?.*?utm_campaign=.",
                 "^https?:\\/\\/(?:[a-z0-9-]+\\.)*?stripe\\.com\\/[^?]+.*?&?referrer=[^/?&]*",
                 "^https?:\\/\\/(?:[a-z0-9-]+\\.)*?lichess\\.org\\/login.*?&?referrer=.*?",
+                "^https?:\\/\\/(?:[a-z0-9-]+\\.)*?microsoft\\.com\\/.*?research\\/redirect",
                 "^https?:\\/\\/like.co\\/api\\/like\\/likebutton\\/[^?]+.*?&?referrer=[^/?&]*",
                 "^https?:\\/\\/button.like.co\\/in\\/.*?&?referrer=[^/?&]*",
                 "^https?:\\/\\/www\\.mma\\.go\\.kr",


### PR DESCRIPTION
Hello, I've noticed that pruning the `?ref=` parameter on some Microsoft URLs can break redirects there.

More specifically when I visit a page like <http://research.microsoft.com/users/lamport/tla/tla.html>, I am redirected to <https://www.microsoft.com/en-us/research/redirect/?ref=https://research.microsoft.com/users/lamport/tla/tla.html> which is transformed by one of the rules to just <https://www.microsoft.com/en-us/research/redirect/>. This obviously can't work, so I ultimately get to the main MS Research page (at <https://www.microsoft.com/en-us/research/?from=https://research.microsoft.com&type=no-match>).

Some other links that get broken because of this are:

* <https://research.microsoft.com/users/lamport/pubs/pubs.html>
* <https://research.microsoft.com/users/lamport/tla/book.html>

and in general, any other Microsoft Research URL [I can find in the wild](https://www.google.com/search?q=%22http%3A%2F%2Fresearch.microsoft.com%2F%22).

i've tried fixing the problem by excluding these `research/redirect` links from the rule that filters `?ref=`. Does it look alright? How should I go about testing it?

Nitpicks are welcome. Once all is clear I'll submit a non-draft version. @KevinRoebert.