### PR TITLE
Add rules for msn

### DIFF
--- a/data.min.json
+++ b/data.min.json
@@ -51,6 +51,19 @@
             "redirections": [],
             "forceRedirection": false
         },
+        "msn": {
+            "urlPattern": "^https?:\\/\\/(?:[a-z0-9-]+\\.)*?msn\\.com",
+            "completeProvider": false,
+            "rules": [
+                "cvid",
+                "ocid"
+            ],
+            "rawRules": [],
+            "referralMarketing": [],
+            "exceptions": [],
+            "redirections": [],
+            "forceRedirection": false
+        },
         "amazon search": {
             "urlPattern": "^https?:\\/\\/(?:[a-z0-9-]+\\.)*?amazon(?:\\.[a-z]{2,}){1,}\\/s\\?",
             "completeProvider": false,


### PR DESCRIPTION
When opening a news using the news widget on Windows the parameters "cvid" and "ocid" are added to the url and can be removed without breaking functionality 