### PR TITLE
Add Amazon dib filter

### DIFF
--- a/data.min.json
+++ b/data.min.json
@@ -35,11 +35,13 @@
                 "camp",
                 "creative",
                 "s",
-                "content-id"
+                "content-id",
+                "dib"
             ],
             "referralMarketing": [
                 "tag",
-                "ascsubtag"
+                "ascsubtag",
+                "dib_tag"
             ],
             "exceptions": [
                 "^https?:\\/\\/(?:[a-z0-9-]+\\.)*?amazon(?:\\.[a-z]{2,}){1,}\\/gp\\/.*?(?:redirector.html|cart\\/ajax-update.html|video\\/api\\/)",


### PR DESCRIPTION
Currently Amazon URLs will display something along the lines of

> https://www.amazon.com/Item-Name/dp/ABCDEF123456?dib=super_long_string&dib_tag=se

This change is to handle and remove the `dib` and `dib_tag` values, which are not necessary.