### PR TITLE
Block GA4 auto-tagging

### DIFF
--- a/data.min.json
+++ b/data.min.json
@@ -246,6 +246,7 @@
                 "(?:%3F)?mkt_tok",
                 "(?:%3F)?hmb_(?:campaign|medium|source)",
                 "(?:%3F)?gclid",
+                "(?:%3F)?srsltid",
                 "(?:%3F)?otm_[a-z_]*",
                 "(?:%3F)?cmpid",
                 "(?:%3F)?os_ehash",


### PR DESCRIPTION
Block `srsltid` parameter.

Docs: https://support.google.com/analytics/answer/11479699?hl=en

Encountered on homedepot.com.