### PR TITLE
Add amazon "social_share" related filters

### DIFF
--- a/data.min.json
+++ b/data.min.json
@@ -37,7 +37,10 @@
                 "s",
                 "content-id",
                 "dib",
-                "dib_tag"
+                "dib_tag",
+                "social_share",
+                "starsLeft",
+                "skipTwisterOG"
             ],
             "referralMarketing": [
                 "tag",


### PR DESCRIPTION
* The `social_share` query string is present whenever you share a product.
* The `starsLeft` and `skipTwisterOG` are carried over from the app, and tracks which reviews the sharer was checking before they shared the link.