### PR TITLE
Add rule for Reddit's "share_id" query parameter

### DIFF
--- a/data.min.json
+++ b/data.min.json
@@ -524,7 +524,8 @@
                 "\\$3p",
                 "%24original_url",
                 "\\$original_url",
-                "_branch_match_id"
+                "_branch_match_id",
+                "share_id"
             ],
             "referralMarketing": [],
             "rawRules": [],


### PR DESCRIPTION
Additional context: https://www.reddit.com/r/privacy/comments/18u7q0v/reddit_now_tracks_whose_links_you_click_and_this/