### PR TITLE
Update YouTube

### DIFF
--- a/data.min.json
+++ b/data.min.json
@@ -395,7 +395,8 @@
                 "feature",
                 "gclid",
                 "kw" ,
-                "si"
+                "si",
+                "pp"
             ],
             "referralMarketing": [],
             "rawRules": [],


### PR DESCRIPTION
Adds the "pp" query param. 

This query value is base64 encoded and typically holds some control characters as well as the query that the user last searched. Regularly reaches lengths of 30+, which clutters the link, and can also be unique to the user which will allow this parameter to be used as tracking.