### PR TITLE
Add xiaohongshu / rednote rules

### DIFF
--- a/data.min.json
+++ b/data.min.json
@@ -1936,6 +1936,33 @@
             "redirections": [],
             "forceRedirection": false
         },
+        "xiaohongshu.com": {
+            "urlPattern": "^https?:\\/\\/(?:[a-z0-9-]+\\.)*?xiaohongshu\\.com",
+            "completeProvider": false,
+            "rules": [
+                "xhsshare",
+                "author_share",
+                "type",
+                "xsec_source",
+                "share_from_user_hidden",
+                "app_version",
+                "ignoreEngage",
+                "app_platform",
+                "apptime",
+                "appuid",
+                "shareRedId",
+                "share_id",
+                "exSource",
+                "verifyUuid",
+                "verifyType",
+                "verifyBiz"
+            ],
+            "referralMarketing": [],
+            "rawRules": [],
+            "exceptions": [],
+            "redirections": [],
+            "forceRedirection": false
+        },
         "autoplus.fr": {
             "urlPattern": "^https?:\\/\\/(?:[a-z0-9-]+\\.)*?autoplus\\.fr",
             "completeProvider": false,


### PR DESCRIPTION
Adds the following rules for XHS. These parameters are populated server side through a redirect to xiaohongshu.com whenever a link-follower clicks an xhslink.com URL (short form URL like TikTok's vm. subdomain URLs). 

Please do not add "xsec_token" to these rules. That query parameter seems to be needed to keep the integrity of the URL for paths like /explore/ and /discovery/item/ (video content), although it is not strictly required for profile shares or maybe other pages.

xhsshare (which share button the sharer pressed to get this link)
author_share (=1 almost always)
type (=video, =normal...)
xsec_source (e.g. =app_share)
share_from_user_hidden (=true, =false)
app_version (semver)
ignoredEngage (=true, =false)
app_platform (e.g. =android)
apptime (epoch time)
appuid (tracking, unique to sharer app download)
shareRedId (tracking, ~35 hexadecimals and case sensitive)
share_id (tracking, ~40 decimal number encoded to hex)
exSource (empty...)
verifyUuid (captcha)
verifyType (captcha)
verifyBiz (captcha)