### PR TITLE
Unbreak Firefox Sync

### DIFF
--- a/data.min.json
+++ b/data.min.json
@@ -394,7 +394,7 @@
             "rules": [
                 "feature",
                 "gclid",
-                "kw" ,
+                "kw",
                 "si"
             ],
             "referralMarketing": [],
@@ -1409,7 +1409,6 @@
             "urlPattern": "^https?:\\/\\/(?:accounts\\.)?firefox\\.com",
             "completeProvider": false,
             "rules": [
-                "context",
                 "entrypoint",
                 "form_type"
             ],
@@ -2986,7 +2985,7 @@
             "redirections": [],
             "forceRedirection": false
         },
-        "shopee": { 
+        "shopee": {
             "urlPattern": "^https?:\\/\\/(?:[a-z0-9-]+\\.)*?shopee\\.(com|co\\.th)",
             "completeProvider": false,
             "rules": [
@@ -3000,7 +2999,7 @@
             "redirections": [],
             "forceRedirection": false
         },
-        "lazada": { 
+        "lazada": {
             "urlPattern": "^https?:\\/\\/(?:[a-z0-9-]+\\.)*?lazada\\.(com|co\\.th|co\\.id|com\\.my|com\\.ph|sg|vn)",
             "completeProvider": false,
             "rules": [
@@ -3026,7 +3025,7 @@
             "redirections": [],
             "forceRedirection": false
         },
-        "pantip.com": { 
+        "pantip.com": {
             "urlPattern": "^https?:\\/\\/(?:[a-z0-9-]+\\.)*?pantip\\.com",
             "completeProvider": false,
             "rules": [],


### PR DESCRIPTION
We ([IronFox](https://ironfoxoss.org/)) have received several reports from users that ClearURLs is breaking Firefox Sync. After some testing, it appears to be due to the `context` parameter being stripped from `accounts.firefox.com`. This fixes it.