### PR TITLE
Add redirection rules for mozgcp.net in addons.mozilla.org

### DIFF
--- a/data.min.json
+++ b/data.min.json
@@ -3099,6 +3099,18 @@
             "exceptions": [],
             "redirections": [],
             "forceRedirection": false
+        },
+        "mozgcp.net": { 
+            "urlPattern": "^https?:\\/\\/(?:[a-z0-9-]+\\.)*?mozgcp\\.net",
+            "completeProvider": false,
+            "rules": [],
+            "rawRules": [],
+            "referralMarketing": [],
+            "exceptions": [],
+            "redirections": [
+              "^https?:\\/\\/prod\\.outgoing\\.prod\\.webservices\\.mozgcp\\.net\\/v1\\/.+?\\/([^&]+)"
+            ],
+            "forceRedirection": false
         }
     }
 }


### PR DESCRIPTION
In Firefox Add-ons website, external links are wrapped like this: https://prod.outgoing.prod.webservices.mozgcp.net/v1/8a4c4de845953bc85d10c6465c5c0f11210b5ca1c195b70d7ddfcf8b74592477/https%3A//clearurls.xyz/

The wrapper seems benign and not needed. Redirection is safe in this case.