### PR TITLE
Retain search state when navigating from Xiaohongshu hover cards

### DIFF
--- a/data.min.json
+++ b/data.min.json
@@ -379,7 +379,7 @@
             "rules": [
                 "feature",
                 "gclid",
-                "kw" ,
+                "kw",
                 "si",
                 "pp"
             ],
@@ -1959,7 +1959,9 @@
             ],
             "referralMarketing": [],
             "rawRules": [],
-            "exceptions": [],
+            "exceptions": [
+                "^https?:\\/\\/edith\\.xiaohongshu\\.com\\/api\\/sns\\/web\\/v1\\/user\\/hover_card"
+            ],
             "redirections": [],
             "forceRedirection": false
         },
@@ -3077,7 +3079,7 @@
             ],
             "forceRedirection": false
         },
-        "office-partner.de": { 
+        "office-partner.de": {
             "urlPattern": "^https?:\\/\\/(?:[a-z0-9-]+\\.)*?office-partner\\.de",
             "completeProvider": false,
             "rules": [


### PR DESCRIPTION
This PR resolves an issue where users were unable to return to the search results page after clicking on a user's hover card within Xiaohongshu search.  The search context is now properly preserved, allowing users to seamlessly continue their search.