### PR TITLE
Fix Steam Support `kb_article.php` links

### DIFF
--- a/data.min.json
+++ b/data.min.json
@@ -299,7 +299,7 @@
                 "^https?:\\/\\/git(lab)?\\.[^/]*\\/[^?]+\\?.*?&?ref_?=[^/?&]*",
                 "^https?:\\/\\/(?:[a-z0-9-]+\\.)*?amazon(?:\\.[a-z]{2,}){1,}\\/message-us\\?",
                 "^https?:\\/\\/authorization\\.td\\.com",
-                "^https?:\\/\\/support\\.steampowered\\.com",
+                "^https?:\\/\\/(?:help|support)\\.steampowered\\.com",
                 "^https?:\\/\\/privacy\\.vakmedianet\\.nl\\/.*?ref=",
                 "^https?:\\/\\/sso\\.serverplan\\.com\\/manage2fa\\/check\\?ref=",
                 "^https?:\\/\\/login\\.meijer\\.com\\/.*?\\?ref=",


### PR DESCRIPTION
The `ref=` parameter was getting removed, which breaks links like this one: https://help.steampowered.com/en/redirects/kb_article.php?ref=4045-USHJ-3810