### PR TITLE
Adding a bunch of ebay rules

### DIFF
--- a/data.min.json
+++ b/data.min.json
@@ -657,10 +657,17 @@
             "urlPattern": "^https?:\\/\\/(?:[a-z0-9-]+\\.)*?ebay(?:\\.[a-z]{2,}){1,}",
             "completeProvider": false,
             "rules": [
+                "_sacat",
+                "_skw",
                 "_trkparms",
                 "_trksid",
                 "_from",
-                "hash"
+                "hash",
+                "epid",
+                "itmmeta",
+                "itmprp",
+                "LH_ItemCondition",
+                "rt"                
             ],
             "referralMarketing": [],
             "rawRules": [],

--- a/data.min.json
+++ b/data.min.json
@@ -666,7 +666,6 @@
                 "epid",
                 "itmmeta",
                 "itmprp",
-                "LH_ItemCondition",
                 "rt"                
             ],
             "referralMarketing": [],

--- a/data.min.json
+++ b/data.min.json
@@ -657,11 +657,11 @@
             "urlPattern": "^https?:\\/\\/(?:[a-z0-9-]+\\.)*?ebay(?:\\.[a-z]{2,}){1,}",
             "completeProvider": false,
             "rules": [
-                "_sacat",
-                "_skw",
                 "_trkparms",
                 "_trksid",
                 "_from",
+                "_sacat",
+                "_skw",
                 "hash",
                 "epid",
                 "itmmeta",


### PR DESCRIPTION
ClearURLs had been lacking on ebay for some time, so I took it upon myself to add as much as I could remove while browsing, without affecting my intended destinations.

Added:  
- "_skw",
- "epid",
- "itmmeta",
- "itmprp"

Examples like the following url can occur on any search or product page depending on context like previous pages visited, clicks, etc.  
https://www.ebay.com/itm/236817343777?_skw=google%20pixel%20unlocked%205g&epid=4085693631&itmmeta=01KRN2CCBSDNH1J5Y7VPGXT1B9&itmprp=enc%3AAQALAAAA8GfYFPkwiKCW4ZNSs2u11xA2XQxfV6h0OqNL13XiZmv9uVGssq%2B6V0kcyf3G2KsiaQ9cqiSxaNKevfkpRqCZsOgvkMXBlA17xBPAHGX7XWo4h%2F2FXJG1FzCTMcSn46h0LBwUoRTNwiUR92owE6JuOCcg2CfrOwxK6%2FKDrRDRq0poQL0NBbYYF2kxMXqzUw8F5vLds4YhM1cWkWmPB0c5cBKrlryZ7Sm2ds4DzTx0Jr3OiTIDDjYPC6a2FUvnkAsadp5%2BRVdrRTIlvMIOwQ4PgxJqIO2rUYojwur2O0v3s%2B9p3GKxXonNfqW20jaq6oe8xw%3D%3D|tkp%3ABk9SR4zHsaLFZw

Added:  
- "_sacat"

Unsure what this does, but it seems to have nothing to do with loading the page.
https://www.ebay.com/sch/i.html?_nkw=rubber+bands&_sacat=0&_from=R40&_trksid=p2334524.m570.l1313

Added:  
- "rt"

I found examples like the following url when browsing shop pages. Removing it changes seemingly nothing.
https://www.ebay.com/sch/i.html?item=397922594342&rt=nc&_trksid=p4429486.m145687.l2562&_ssn=madyma_0