### PR TITLE
Extend rule for aliexpress (#17, #163, #301, #307)

### DIFF
--- a/data.min.json
+++ b/data.min.json
@@ -945,7 +945,17 @@
                 "sk",
                 "dp",
                 "terminal_id",
-                "aff_request_id"
+                "aff_request_id",
+                "businessType",
+                "sku_id",
+                "spreadType",
+                "srcSns",
+                "pvid",
+                "_t",
+                "pdp_ext_f",
+                "pdp_npi",
+                "search_p4p_id",
+                "algo_exp_id"
             ],
             "referralMarketing": [],
             "rawRules": [],


### PR DESCRIPTION
Solution for #17, #163, #301, #307 as well as my own addition of parameters

Example:
`https://ali.click/fk3ej1c` → `https://aliexpress.ru/item/1005009450643460.html?businessType=ProductDetail&sku_id=12000049142896049&spm=a2g2l.detail.0.0&spreadType=socialShare&srcSns=sns_More&utm_medium=sharing` → `https://aliexpress.ru/item/1005009450643460.html`