### PR TITLE
Extend rule for ozon[.]ru

### DIFF
--- a/data.min.json
+++ b/data.min.json
@@ -1096,7 +1096,11 @@
             "urlPattern": "^https?:\\/\\/(?:[a-z0-9-]+\\.)*?ozon\\.ru",
             "completeProvider": false,
             "rules": [
-                "partner"
+                "partner",
+                "from",
+                "perehod",
+                "sh",
+                "short"
             ],
             "referralMarketing": [],
             "rawRules": [],


### PR DESCRIPTION
Example:

`https://ozon.ru/t/BSabeIf` → `https://www.ozon.ru/product/polka-dlya-basseyna-s-krepleniem-na-bortik-udobnoe-hranenie-veshchey-vo-vremya-plavaniya-i-igr-5049222748/?from=share_android&perehod=smm_share_button_productpage_link&sh=0Y5kEbm7IQ&short=BSabeIf` → `https://www.ozon.ru/product/polka-dlya-basseyna-s-krepleniem-na-bortik-udobnoe-hranenie-veshchey-vo-vremya-plavaniya-i-igr-5049222748/`