### PR TITLE
Extend rule for Yandex (Yandex.Market specifically)

### DIFF
--- a/data.min.json
+++ b/data.min.json
@@ -1331,9 +1331,20 @@
             "completeProvider": false,
             "rules": [
                 "lr",
-                "redircnt"
+                "redircnt",
+                "stock_amount",
+                "isComfortPlus",
+                "isGroupPurchaseFlow",
+                "cpa",
+                "ogV"
             ],
-            "referralMarketing": [],
+            "referralMarketing": [
+                "nid",
+                "hid",
+                "offerid",
+                "publicId",
+                "do-waremd5"
+            ],
             "rawRules": [],
             "exceptions": [],
             "redirections": [],


### PR DESCRIPTION
Expanding `yandex` rule since no separate rule for Yandex.Market exists

`referralMarketing` parameters were selected by a rule of thumb

Example:

`https://market.yandex.ru/cc/AjCKAp` → `https://market.yandex.ru/card/umnaya-kolonka-yandeks-stantsiya-3-fioletovaya/4803949521?nid=70203666&isComfortPlus=false&isGroupPurchaseFlow=false&offerid=eVucsvkHQ_4SsPYca5Ko8A&cpa=1&hid=70203513&publicId=pj5t0qndwpx14cbh8u75xh70rc&utm_medium=sharing&stock_amount=10&ogV=300&do-waremd5=eVucsvkHQ_4SsPYca5Ko8A` → `https://market.yandex.ru/card/umnaya-kolonka-yandeks-stantsiya-3-fioletovaya/4803949521`